### PR TITLE
Fixes Issue #291

### DIFF
--- a/acs/ac1/_sources/basic_descriptive_statistics/summary.rst
+++ b/acs/ac1/_sources/basic_descriptive_statistics/summary.rst
@@ -3,6 +3,9 @@
    International License. To view a copy of this license, visit
    http://creativecommons.org/licenses/by-sa/4.0/.
 
+Summary
+=======
+
 .. image:: figures/statistics_summary.png
    :align: center
    :alt: Graphic summarizing key concepts of basic descriptive statistics.

--- a/acs/ac1/_sources/filtering_and_grouping/summary.rst
+++ b/acs/ac1/_sources/filtering_and_grouping/summary.rst
@@ -3,5 +3,8 @@
     International License. To view a copy of this license, visit
     http://creativecommons.org/licenses/by-sa/4.0/.
 
+Summary
+=======
+
 .. image:: figures/summary.png
    :align: center

--- a/acs/ac1/_sources/sheets_basics/summary.rst
+++ b/acs/ac1/_sources/sheets_basics/summary.rst
@@ -3,6 +3,9 @@
    International License. To view a copy of this license, visit
    http://creativecommons.org/licenses/by-sa/4.0/.
 
+Summary
+=======
+
 .. image:: figures/sheets_summary.png
    :align: center
    :alt: Graphic summarizing key concepts of Sheets basics.


### PR DESCRIPTION
Runestone was producing warnings because summaries were not appearing in table of contents. This was fixed by adding the Summary title to each of these pages. 